### PR TITLE
generate temp files in system temporary directory - fixes issue #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,14 @@ const ffprobe = require('ffprobe-static');
 const ffmpeg = require('ffmpeg-static');
 const shortid = require('shortid').generate;
 const boxjam = require('boxjam');
+const os = require('os');
+const path = require('path')
+
+// generate a temporary filename in the system temporary directory
+// given the file's extension
+const tmp = (extension) => {
+  return path.join(os.tmpdir(), `${shortid()}${extension}`) 
+}
 
 // Delete created files when they've been loaded into memory
 // or if the program crashes.
@@ -62,7 +70,7 @@ function stitchVideo(videos, container, margin, shouldCenter, returnAsFile, pan)
 
     return new Promise( (resolve, reject) => {
 
-        const OUTPUT_FILE_NAME = `${__dirname}/${shortid()}.mp4`
+        const OUTPUT_FILE_NAME = tmp('.mp4')
         const boxes = boxjam(videos, container, margin, shouldCenter);
 
         let FILTER = `"[0:v]scale=${container.width}:${container.height}[bg]; `


### PR DESCRIPTION
Small fix to ensure that temp files are created in a directory that will be cleaned up by the OS. As it stands, when using Stitcheroo as a dependency, mp4 files get stored in your project's node_modules.